### PR TITLE
fix: update dependency for driver

### DIFF
--- a/databend_sqlalchemy/__init__.py
+++ b/databend_sqlalchemy/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 
 
-VERSION = (0, 4, 0)
+VERSION = (0, 4, 1)
 __version__ = ".".join(str(x) for x in VERSION)

--- a/databend_sqlalchemy/connector.py
+++ b/databend_sqlalchemy/connector.py
@@ -9,7 +9,7 @@ import uuid
 from datetime import datetime
 from databend_sqlalchemy.errors import ServerException, NotSupportedError
 
-from databend_py import BlockingDatabendClient
+from databend_driver import BlockingDatabendClient
 
 # PEP 249 module globals
 apilevel = "2.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    databend_py>=0.5.0
+    databend__driver>=0.12.1
     sqlalchemy>1.3.21,<2.0
 python_requires = >=3.7
 package_dir =


### PR DESCRIPTION
`databend-sqlalchemy` and `databend-py` both depend on `databend-driver`. They are in the same layer and should not depend on each other.