### PR TITLE
fix: upgrade databend-driver to 0.13.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    databend-driver>=0.12.3
+    databend-driver>=0.13.0
     sqlalchemy>1.3.21
 python_requires = >=3.7
 package_dir =


### PR DESCRIPTION
The lowest databend driver version to 0.13.0 to fix timeout sql.