### PR TITLE
fix: keep timezone-aware datetimes aware and UTC-normalise naive coercion

### DIFF
--- a/databend_sqlalchemy/databend_dialect.py
+++ b/databend_sqlalchemy/databend_dialect.py
@@ -737,8 +737,14 @@ class DatabendDateTime(sqltypes.DATETIME):
                         "could not parse %r as a datetime value" % (value,)
                     )
                 return datetime.datetime(*[int(x or 0) for x in m.groups()])
-            else:
-                return value.replace(tzinfo=None)
+            if value.tzinfo is not None and not self.timezone:
+                # The driver returns tz-aware (UTC) datetimes, but a
+                # timezone=False column must yield naive values to honour
+                # SQLAlchemy's typing contract. Normalise to UTC before
+                # dropping tzinfo so a non-UTC offset doesn't shift the
+                # wall-clock; a timezone=True column keeps its awareness.
+                return value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+            return value
 
         return process
 

--- a/tests/unit/test_databend_dialect.py
+++ b/tests/unit/test_databend_dialect.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 from unittest import mock
 
@@ -228,3 +229,32 @@ def test_extract_nullable_string():
         assert expected_types[i] == true_type
         i += 1
         print(true_type)
+
+
+def test_datetime_result_processor_timezone_handling():
+    # The driver returns tz-aware (UTC) datetimes; a plain DateTime()/TIMESTAMP
+    # column (timezone=False) must yield naive values so the compliance suite's
+    # naive round-trips hold, while a timezone=True column keeps its awareness.
+    DatabendDateTime = databend_sqlalchemy.databend_dialect.DatabendDateTime
+    aware_utc = datetime.datetime(
+        2012, 10, 15, 12, 57, 18, 396, tzinfo=datetime.timezone.utc
+    )
+    naive = datetime.datetime(2012, 10, 15, 12, 57, 18, 396)
+
+    process = DatabendDateTime().result_processor(None, None)
+    # tz-aware input -> naive output for a timezone=False column
+    assert process(aware_utc) == naive
+    assert process(aware_utc).tzinfo is None
+    # a non-UTC offset is normalised to UTC before tzinfo is dropped, so the
+    # wall-clock is converted rather than merely truncated
+    aware_plus2 = aware_utc.astimezone(datetime.timezone(datetime.timedelta(hours=2)))
+    assert process(aware_plus2) == naive
+    # naive passes through unchanged; None is preserved; strings still parse
+    assert process(naive) == naive
+    assert process(None) is None
+    assert process("2012-10-15 12:57:18.000396") == naive
+
+    # timezone=True columns keep their tzinfo untouched
+    process_tz = DatabendDateTime(timezone=True).result_processor(None, None)
+    assert process_tz(aware_utc) == aware_utc
+    assert process_tz(aware_utc).tzinfo is not None


### PR DESCRIPTION
## Problem

`DatabendDateTime.result_processor` currently coerces every non-string value with an unconditional `value.replace(tzinfo=None)`:

```python
else:
    return value.replace(tzinfo=None)
```

The driver returns tz-aware (UTC) datetimes, so this does fix the naive-column case — but it has two side effects:

1. **It clobbers `timezone=True` columns.** A `DateTime(timezone=True)` / `TIMESTAMP WITH TIME ZONE` column loses its tzinfo, even though `self.timezone` is available (inherited from `sqltypes.DATETIME`) to distinguish the two cases.
2. **It drops tzinfo without converting to UTC first.** If the driver ever returns a tz-aware value carrying a non-UTC offset, `replace(tzinfo=None)` truncates the offset instead of converting it — yielding the wrong naive wall-clock (e.g. a `+02:00` value comes back two hours off).

## Fix

```python
if value.tzinfo is not None and not self.timezone:
    return value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
return value
```

- `timezone=False` columns still yield naive values (so the compliance suite's naive round-trips hold), but the value is normalised to UTC before tzinfo is dropped, so the wall-clock is correct regardless of the driver's offset.
- `timezone=True` columns are returned unchanged, keeping their awareness.
- `None` and string inputs are handled exactly as before.

## Tests

`tests/unit/test_databend_dialect.py` — server-less, calls `result_processor` directly:

- tz-aware UTC input → naive output for a `timezone=False` column;
- a non-UTC (`+02:00`) input is normalised to UTC, not merely truncated;
- naive passes through unchanged, `None` is preserved, strings still parse;
- a `timezone=True` column keeps its tzinfo.